### PR TITLE
Updated for more strict WebGL 2.0 semantics.

### DIFF
--- a/js/GPGPU.js
+++ b/js/GPGPU.js
@@ -49,6 +49,11 @@ var GPGPU2 = function ( renderer ) {
 
       gl.endTransformFeedback();
       gl.disable(gl.RASTERIZER_DISCARD);
+
+      // Unbind the transform feedback buffer so subsequent attempts
+      // to bind it to ARRAY_BUFFER work.
+      gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
+
       //gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, 0);
     }
   };


### PR DESCRIPTION
@toji @zhenyao please review.

Note that as the new binding semantics in the spec broke this code, we should consider whether we want the bind operation to fail, or subsequent draw calls to fail. We might break existing ES 3.0 apps with these semantics.
